### PR TITLE
Clean higher-level-containers notebook

### DIFF
--- a/notebooks/06.10-higher-level-containers.ipynb
+++ b/notebooks/06.10-higher-level-containers.ipynb
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid = GridspecLayout(4, 3, height='300px')\n",
+    "grid = GridspecLayout(4, 3)\n",
     "grid[:3, 1:] = create_expanded_button('One', 'success')\n",
     "grid[:, 0] = create_expanded_button('Two', 'info')\n",
     "grid[3, 1] = create_expanded_button('Three', 'warning')\n",
@@ -453,7 +453,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid = GridspecLayout(4, 3, height='300px')\n",
+    "grid = GridspecLayout(4, 3)\n",
     "grid[:3, 1:] = create_expanded_button('One', 'success')\n",
     "grid[:, 0] = create_expanded_button('Two', 'info')\n",
     "grid[3, 1] = create_expanded_button('Three', 'warning')\n",
@@ -492,7 +492,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid = GridspecLayout(4, 3, height='300px')\n",
+    "grid = GridspecLayout(4, 3)\n",
     "grid[:3, 1:] = create_expanded_button('One', 'info')\n",
     "grid[:, 0] = create_expanded_button('Two', 'info')\n",
     "grid[3, 1] = create_expanded_button('Three', 'info')\n",


### PR DESCRIPTION
The GridSpecLayout is clearer using natural button sizes