### PR TITLE
[BUG] Added xarray to dependecies

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -25,5 +25,6 @@ dependencies:
   - voila-vuetify
   - jupyterlab=2
   - ipyvolume=0.6.0a6
+  - xarray
   - pip:
     - netcdf4

--- a/environment.yml
+++ b/environment.yml
@@ -27,3 +27,4 @@ dependencies:
   - jupyterlab=2
   - ipyvolume=0.6.0a6
   - nodejs=13
+  - xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ ipyvuetify
 voila-vuetify
 sidecar
 ipyvolume==0.6.0-a.6
+xarray


### PR DESCRIPTION
The notebook [07.01-ipyleaflet.ipynb](https://github.com/jupyter-widgets/tutorial/blob/master/notebooks/07.01-ipyleaflet.ipynb) uses `xarray`, which isn't part of the dependencies and thus `Advanced example 1: Velocity` can't be executed on binder.

IMHO adding `netcdf4` to the normal dependencies and making the download code for the [`wind-global.nc` dataset](https://github.com/benbovy/xvelmap/raw/master/notebooks/wind-global.nc) a code cell instead of an instruction in a markdown cell would be an improvement.