### PR TITLE
Use --minimize=False on Binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,4 @@
 ipython kernel install --name widgets-tutorial --display-name widgets-tutorial --sys-prefix
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager @jupyter-widgets/jupyterlab-sidecar bqplot jupyter-threejs jupyter-leaflet@0.12.6 ipysheet ipytree ipycanvas jupyter-matplotlib jupyter-vuetify ipyvolume
+jupyter labextension install @jupyter-widgets/jupyterlab-manager @jupyter-widgets/jupyterlab-sidecar bqplot jupyter-threejs jupyter-leaflet@0.12.6 ipysheet ipytree ipycanvas jupyter-matplotlib jupyter-vuetify ipyvolume --no-build
+jupyter lab build --minimize=False


### PR DESCRIPTION
To avoid high memory usage issues when running `jupyter lab build`.