### PR TITLE
Add action to create binder link to PR on comment

### DIFF
--- a/.github/workflows/chatops-binder.yaml
+++ b/.github/workflows/chatops-binder.yaml
@@ -1,0 +1,34 @@
+# Copied from https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html#example-2-comment-with-a-binder-badge-in-response-to-a-comment
+name: Chatops Binder
+on: [issue_comment] # issues and PRs are equivalent in terms of comments for the GitHub API
+
+jobs:
+  trigger-chatops:
+    # Make sure the comment is on a PR, and contains the command "/binder"
+    if: (github.event.issue.pull_request != null) &&  contains(github.event.comment.body, '/binder')
+    runs-on: ubuntu-latest
+    steps:
+      # Use the GitHub API to: 
+      #  (1) Get the branch name of the PR that has been commented on with "/binder" 
+      #  (2) make a comment on the PR with the binder badge
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          // Get the branch name
+          github.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.issue.number
+          }).then( (pr) => {
+
+            // use the branch name to make a comment  on the PR with a Binder badge
+            var BRANCH_NAME = pr.data.head.ref
+            github.issues.createComment({
+              issue_number: context.payload.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}) :point_left: Launch a binder notebook on this branch`
+            })
+          })


### PR DESCRIPTION
This action will add a comment on a PR to the binder for that PR if someone comments on the PR with the phrase `/binder`. Seems potentially useful for taking a quick look at PRs and/or trying out changes to our binder configuration.