### PR TITLE
Drop `ButtonStyle`

### DIFF
--- a/notebooks/06.01-widget-layout-and-styling.ipynb
+++ b/notebooks/06.01-widget-layout-and-styling.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "from ipywidgets import Button, ButtonStyle\n",
-    "b2 = Button(description='Custom color', style=ButtonStyle(button_color = 'lightgreen'))\n",
+    "b2 = Button(description='Custom color', style=dict(button_color='lightgreen'))\n",
     "b2"
    ]
   },


### PR DESCRIPTION
A dict works fine, and users don't need to have the impressions there is
a separate style class for each widget.