### PR TITLE
modernize matplotlib sections of interact notebook

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,4 +28,5 @@ dependencies:
   - sidecar=0.5.1
   - voila=0.3.5
   - vtk=9.1.0
-  - mpl_interactions=0.22.0
+  - pip:
+    - mpl_interactions==0.22.0

--- a/environment.yml
+++ b/environment.yml
@@ -28,3 +28,4 @@ dependencies:
   - sidecar=0.5.1
   - voila=0.3.5
   - vtk=9.1.0
+  - mpl_interactions=0.22.0

--- a/notebooks/02.Interact/02.00-Using-Interact.ipynb
+++ b/notebooks/02.Interact/02.00-Using-Interact.ipynb
@@ -25,7 +25,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from ipywidgets import interact, interactive, fixed, interact_manual\n",
@@ -294,10 +296,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# %load solutions/reverse-text.py\n"
+    "# %load solutions/reverse-text.py"
    ]
   },
   {
@@ -351,26 +355,36 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Basic interactive plot\n",
     "\n",
-    "Though the examples so far in this notebook had very basic output, more interesting possibilities are straightforward. \n",
     "\n",
-    "The function below plots a straight line whose slope and intercept are given by its arguments."
+    "The function below plots a straight line whose slope and intercept are given by its arguments.\n",
+    "\n",
+    "The interactive below displays a line whose slope and intercept is set by the sliders. Note that if the variable containing the widget, `interactive_plot`, is the last thing in the cell it is displayed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "\n",
     "def f(m, b):\n",
     "    plt.figure(2)\n",
     "    plt.clf()\n",
@@ -378,20 +392,22 @@
     "    x = np.linspace(-10, 10, num=1000)\n",
     "    plt.plot(x, m * x + b)\n",
     "    plt.ylim(-5, 5)\n",
-    "    plt.show()\n"
+    "    plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The interactive below displays a line whose slope and intercept is set by the sliders. Note that if the variable containing the widget, `interactive_plot`, is the last thing in the cell it is displayed."
+    "The interactive below displays a line whose slope and intercept is set by the sliders."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "interact(f, m=(-2.0, 2.0), b=(-3, 3, 0.5))"
@@ -401,41 +417,128 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercise: Make a plot\n",
+    "## Fully interactive plot\n",
     "\n",
-    "Here is a python function that, given $k$ and $p$, plots $f(x) = \\sin(k x - p)$.\n"
+    "While the above example works, it has some drawbacks:\n",
+    "1. It is inefficient to re-run all the plotting code\n",
+    "2. No zooming or panning\n",
+    "3. Screen can jump when moving the sliders\n",
+    "\n",
+    "A better solution is to use the [ipympl](https://matplotlib.org/ipympl/) Matplotlib backend. You can activate this with the line magic: `%matplotlib ipympl`. Then in your interactive function you update the matplotlib artists."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "def plot_f(k, p):\n",
-    "    plt.figure(5)\n",
-    "    plt.clf()\n",
-    "    plt.grid()\n",
-    "    x = np.linspace(0, 4 * np.pi)\n",
-    "    y = np.sin(k*x - p)\n",
-    "    plt.plot(x, y)\n",
-    "    plt.show()"
+    "# activate the widget based backend.\n",
+    "%matplotlib ipympl\n",
+    "\n",
+    "x = np.linspace(-10, 10, num=1000)\n",
+    "m, b = 0, 0\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.grid()\n",
+    "ax.set_ylim(-5, 5)\n",
+    "line = ax.plot(x, m * x + b)[0]\n",
+    "\n",
+    "\n",
+    "@interact(m=(-2.0, 2.0), b=(-3, 3, 0.5))\n",
+    "def update_line(m, b):\n",
+    "    # use matplotlib functions to update the canvas\n",
+    "    line.set_ydata(m * x + b)\n",
+    "    fig.canvas.draw_idle()\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Copy the above function definition and make it interactive using `interact`, so that there are sliders for the parameters $k$ and $p$, where $0.5\\leq k \\leq 2$ and $0 \\leq p \\leq 2\\pi$ (hint: use `np.pi` for $\\pi$)."
+    "## mpl-interactions\n",
+    "\n",
+    "The [mpl-interactions](https://mpl-interactions.readthedocs.io/en/stable/) library can automate the updating of Matplotlib artists for you. non-matplotlib kwargs to functions like `plot` will be interpted to sliders and widget controls similarly to `interact` and automatically connected with the matplotlib artists."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# %load solutions/plot-function.py"
+    "from mpl_interactions import ipyplot as iplt\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.grid()\n",
+    "ax.set_ylim(-5,5)\n",
+    "\n",
+    "# define function in a way you can re-use in calculations\n",
+    "def f(x, m, b):\n",
+    "    return m * x + b\n",
+    "    \n",
+    "ctrls = iplt.plot(x, f, m = (-2,2), b=(-3, 3, 10))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise: Make a plot\n",
+    "\n",
+    "Here is an example of making a plot of $f(x) = \\sin(k x - p)$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x = np.linspace(0, 4 * np.pi, 100)\n",
+    "k = 1\n",
+    "p = np.pi\n",
+    "\n",
+    "def f(x, k, p):\n",
+    "    return np.sin(k*x -p)\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.grid()\n",
+    "ax.plot(x, f(x, k, p))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copy the above function definition and make it interactive using `interact` or `mpl-interactions`, so that there are sliders for the parameters $k$ and $p$, where $0.5\\leq k \\leq 2$ and $0 \\leq p \\leq 2\\pi$ (hint: use `np.pi` for $\\pi$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# %load solutions/plot-function-interact.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# %load solutions/plot-function-mpl-inter.py"
    ]
   },
   {
@@ -460,9 +563,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "widgets-tutorial",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "widgets-tutorial"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -474,7 +577,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/02.Interact/02.00-Using-Interact.ipynb
+++ b/notebooks/02.Interact/02.00-Using-Interact.ipynb
@@ -355,13 +355,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -370,9 +363,7 @@
     "## Basic interactive plot\n",
     "\n",
     "\n",
-    "The function below plots a straight line whose slope and intercept are given by its arguments.\n",
-    "\n",
-    "The interactive below displays a line whose slope and intercept is set by the sliders. Note that if the variable containing the widget, `interactive_plot`, is the last thing in the cell it is displayed."
+    "The function below plots a straight line whose slope and intercept are given by its arguments."
    ]
   },
   {
@@ -385,31 +376,16 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "\n",
     "def f(m, b):\n",
-    "    plt.figure(2)\n",
+    "    fig = plt.figure()\n",
     "    plt.clf()\n",
     "    plt.grid()\n",
     "    x = np.linspace(-10, 10, num=1000)\n",
     "    plt.plot(x, m * x + b)\n",
     "    plt.ylim(-5, 5)\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The interactive below displays a line whose slope and intercept is set by the sliders."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "    plt.show()\n",
+    "\n",
     "interact(f, m=(-2.0, 2.0), b=(-3, 3, 0.5))"
    ]
   },
@@ -420,11 +396,11 @@
     "## Fully interactive plot\n",
     "\n",
     "While the above example works, it has some drawbacks:\n",
-    "1. It is inefficient to re-run all the plotting code\n",
+    "1. It is inefficient to re-run all the plotting code (the whole plot gets re-created every time -- to see this, run the code above again after running the cell below and see how the figure numbers get incremented)\n",
     "2. No zooming or panning\n",
     "3. Screen can jump when moving the sliders\n",
     "\n",
-    "A better solution is to use the [ipympl](https://matplotlib.org/ipympl/) Matplotlib backend. You can activate this with the line magic: `%matplotlib ipympl`. Then in your interactive function you update the matplotlib artists."
+    "A better solution is to use the [ipympl](https://matplotlib.org/ipympl/) Matplotlib backend. You can activate this with the line magic: `%matplotlib ipympl`."
    ]
   },
   {
@@ -435,23 +411,22 @@
    },
    "outputs": [],
    "source": [
-    "# activate the widget based backend.\n",
+    "# Activate the widget based backend.\n",
     "%matplotlib ipympl\n",
     "\n",
     "x = np.linspace(-10, 10, num=1000)\n",
-    "m, b = 0, 0\n",
-    "\n",
     "fig, ax = plt.subplots()\n",
     "ax.grid()\n",
     "ax.set_ylim(-5, 5)\n",
-    "line = ax.plot(x, m * x + b)[0]\n",
-    "\n",
+    "# Initialize a plot object with y = x. We'll be modifying y below.\n",
+    "# This returns a list of `.Line2D` representing the plotted data. We grab the first one -- we only have 1 series.\n",
+    "line = ax.plot(x, x)[0]\n",
     "\n",
     "@interact(m=(-2.0, 2.0), b=(-3, 3, 0.5))\n",
-    "def update_line(m, b):\n",
-    "    # use matplotlib functions to update the canvas\n",
+    "def update_line(m=1, b=0.5):\n",
     "    line.set_ydata(m * x + b)\n",
-    "    fig.canvas.draw_idle()\n"
+    "    # Request a widget redraw.\n",
+    "    fig.canvas.draw_idle()"
    ]
   },
   {
@@ -460,7 +435,7 @@
    "source": [
     "## mpl-interactions\n",
     "\n",
-    "The [mpl-interactions](https://mpl-interactions.readthedocs.io/en/stable/) library can automate the updating of Matplotlib artists for you. non-matplotlib kwargs to functions like `plot` will be interpted to sliders and widget controls similarly to `interact` and automatically connected with the matplotlib artists."
+    "The [mpl-interactions](https://mpl-interactions.readthedocs.io/en/stable/) library can automate the updating of Matplotlib plots for you. Non-matplotlib keyword arguments passed to functions like `plot` will be interpreted to sliders and widget controls, similarly to `interact`, and automatically connected with the matplotlib plots."
    ]
   },
   {
@@ -477,11 +452,11 @@
     "ax.grid()\n",
     "ax.set_ylim(-5,5)\n",
     "\n",
-    "# define function in a way you can re-use in calculations\n",
+    "# Define function in a way you can re-use in calculations\n",
     "def f(x, m, b):\n",
     "    return m * x + b\n",
     "    \n",
-    "ctrls = iplt.plot(x, f, m = (-2,2), b=(-3, 3, 10))\n"
+    "ctrls = iplt.plot(x, f, m=(-2,2), b=(-3, 3, 10))"
    ]
   },
   {
@@ -509,7 +484,7 @@
     "    return np.sin(k*x -p)\n",
     "fig, ax = plt.subplots()\n",
     "ax.grid()\n",
-    "ax.plot(x, f(x, k, p))\n"
+    "ax.plot(x, f(x, k, p))"
    ]
   },
   {

--- a/notebooks/02.Interact/solutions/plot-function-interact.py
+++ b/notebooks/02.Interact/solutions/plot-function-interact.py
@@ -1,0 +1,12 @@
+# with interact
+
+fig, ax = plt.subplots()
+ax.grid()
+line = ax.plot(x, f(x, k, p))[0]
+
+def plot_f(k, p):
+    line.set_ydata(f(x, k, p))
+    fig.canvas.draw_idle()
+    
+    
+interact(plot_f, k=(0.5, 2), p=(0, 2 * np.pi))

--- a/notebooks/02.Interact/solutions/plot-function-mpl-inter.py
+++ b/notebooks/02.Interact/solutions/plot-function-mpl-inter.py
@@ -1,0 +1,3 @@
+fig, ax = plt.subplots()
+ax.grid()
+ctrls = iplt.plot(x, f, k=(.5, 2), p=(0, 2*np.pi))

--- a/notebooks/02.Interact/solutions/plot-function.py
+++ b/notebooks/02.Interact/solutions/plot-function.py
@@ -1,1 +1,0 @@
-interact(plot_f, k=(0.5, 2), p=(0, 2 * np.pi))

--- a/notebooks/07.More-libraries/07.05-other-widget-libraries.ipynb
+++ b/notebooks/07.More-libraries/07.05-other-widget-libraries.ipynb
@@ -276,7 +276,7 @@
    "source": [
     "# ipympl: The Matplotlib Jupyter Widget Backend\n",
     "\n",
-    "## https://github.com/matplotlib/ipympl\n",
+    "## https://matplotlib.org/ipympl/\n",
     "\n",
     "\n",
     "Enabling interaction with matplotlib charts in the Jupyter notebook and JupyterLab\n",
@@ -295,7 +295,7 @@
    "id": "91a33e30-803d-4945-8129-2c37f30a1d09",
    "metadata": {},
    "source": [
-    "Enabling the `widget` backend. This requires ipympl. ipympl can be install via pip or conda."
+    "Enabling the `ipympl` (sometimes written `widget`) backend. ipympl can be install via pip or conda."
    ]
   },
   {
@@ -305,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib widget"
+    "%matplotlib ipympl"
    ]
   },
   {
@@ -334,19 +334,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9db5b3e0-317c-4b79-bb5c-36786d02895a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "plt.ioff()\n",
-    "plt.clf()\n",
-    "\n",
-    "slider = FloatSlider(\n",
-    "    value=1.0,\n",
-    "    min=0.02,\n",
-    "    max=2.0\n",
-    ")\n",
-    "\n",
-    "fig1 = plt.figure(1)\n",
+    "with plt.ioff():\n",
+    "    fig, ax = plt.subplots()\n",
     "\n",
     "x1 = np.linspace(0, 20, 500)\n",
     "\n",
@@ -354,12 +348,16 @@
     "\n",
     "def update_lines(change):\n",
     "    lines[0].set_data(x1, np.sin(change.new * x1))\n",
-    "    fig1.canvas.draw()\n",
-    "    fig1.canvas.flush_events()\n",
+    "    fig.canvas.draw()\n",
     "\n",
+    "slider = FloatSlider(\n",
+    "    value=1.0,\n",
+    "    min=0.02,\n",
+    "    max=2.0\n",
+    ")\n",
     "slider.observe(update_lines, names='value')\n",
     "\n",
-    "VBox([slider, fig1.canvas])"
+    "VBox([slider, fig.canvas])"
    ]
   },
   {
@@ -451,6 +449,13 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/07.More-libraries/07.05-other-widget-libraries.ipynb
+++ b/notebooks/07.More-libraries/07.05-other-widget-libraries.ipynb
@@ -325,9 +325,9 @@
    "id": "fc9dca28-883c-4286-af3d-a17081b089d6",
    "metadata": {},
    "source": [
-    "When using the `widget` backend from ipympl, fig.canvas is a proper Jupyter interactive widget, which can be embedded in Layout classes like HBox and Vbox.\n",
+    "When using the `widget` backend from ipympl, `fig.canvas` is a proper Jupyter interactive widget, which can be embedded in Layout classes like `HBox` and `VBox`.\n",
     "\n",
-    "One can bound figure attributes to other widget values."
+    "One can bind figure attributes to other widget values."
    ]
   },
   {


### PR DESCRIPTION
Got a little bit longer - could definitely cut stuff out, but felt important to include the original section in order to contrast as otherwise it leaves you with the question of "well why not just do that?".

Could also consider moving `mpl-interactions` to the "other widget libraries" section

closes: https://github.com/jupyter-widgets/tutorial/issues/173

attn: @bsyouness 